### PR TITLE
Feature/kaleb coberly/update whatcom stem references

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Cascade STEAM
+Copyright (c) 2023 Cascade STEAM
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updates org name in license.

The only other references to Whatcom STEM I found in the repo are regarding the name change itself or archived news about the initial formation, so I left those alone.